### PR TITLE
jQuery 1.8 support & wrapper element support

### DIFF
--- a/selectableScroll.js
+++ b/selectableScroll.js
@@ -21,7 +21,7 @@
 (function ($) {
   $.widget('ui.selectableScroll', $.ui.selectable, {
     options: {
-      useParentForScrolling: false, // If true, targets the parent element for scrolling
+      scrollElement: null, // If an element is passed in here, use it for scrolling instead of widget's element
       scrollSnapX: 5, // When the selection is that pixels near to the top/bottom edges, start to scroll
       scrollSnapY: 5, // When the selection is that pixels near to the side edges, start to scroll
       scrollAmount: 25, // In pixels
@@ -38,7 +38,7 @@
       this.element.addClass("ui-selectable");
       this.dragged = false;
       this.helperClasses = ['no-top', 'no-right', 'no-bottom', 'no-left'];
-      this.scrollElement = this._getScrollElement();
+      this.scrollElement = this.options.scrollElement || this.element;
 
       // cache selectee children based on filter
       this.refresh = function() {
@@ -211,17 +211,6 @@
         x2: relX2,
         y2: relY2
       };
-    },
-
-    /**
-     * Returns the element to apply scrolling to. (Sometimes we'll want to use the parent element of the selectable.)
-     */
-    _getScrollElement: function () {
-      if (this.options.useParentForScrolling) {
-        return this.element.parent();
-      }
-
-      return this.element;
     },
 
     /**


### PR DESCRIPTION
I made some modifications to this library for the project I'm working with, and I thought they might be useful for you. First commit is a tweak to support jQuery 1.8, since it doesn't support the method _super() yet. Second commit is addition of "useParentForScrolling" as an option, for situations where the scrolling div needs to be the parent of div with selectable items in it, like this: http://stackoverflow.com/questions/2330773/jquery-ui-selectable-plugin-make-scroll-bar-not-selectable-when-div-overflows 
